### PR TITLE
feat: add maxLength constraint to payment message in OpenAPI specification

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -347,6 +347,7 @@ paths:
                   description: Tempo de expiração da cobrança em segundos.
                 description:
                   type: string
+                  maxLength: 140
                   description: Mensagem que aparecerá na hora do pagamento do PIX.
                 customer:
                   type: object


### PR DESCRIPTION
![{314CA9CB-85BB-4924-902C-F49E9F08E6EA}](https://github.com/user-attachments/assets/69cbe8ce-5b18-4ec6-adba-5a876f379f6d)