### PR TITLE
feat: add allow coupons details to docs

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -50,7 +50,7 @@ paths:
                   data:
                     $ref: '#/components/schemas/Customer'
                   error:
-                    type: null
+                    type: 'null'
         '401':
           description: Não autorizado. Falha na autenticação.
           content:
@@ -82,7 +82,7 @@ paths:
                     items:
                       $ref: '#/components/schemas/Customer'
                   error:
-                    type: null
+                    type: 'null'
         '401':
           description: Não autorizado. Falha na autenticação.
           content:
@@ -110,7 +110,7 @@ paths:
                 data:
                   $ref: '#/components/schemas/Coupon'
                 error:
-                  type: null
+                  type: 'null'
       responses:
         '200':
           description: Cliente criado com sucesso.
@@ -122,7 +122,7 @@ paths:
                   data:
                     $ref: '#/components/schemas/CouponResponse'
                   error:
-                    type: null
+                    type: 'null'
         '401':
           description: Não autorizado. Falha na autenticação.
           content:
@@ -154,7 +154,7 @@ paths:
                     items:
                       $ref: '#/components/schemas/CouponResponse'
                   error:
-                    type: null
+                    type: 'null'
         '401':
           description: Não autorizado. Falha na autenticação.
           content:
@@ -269,6 +269,20 @@ paths:
                       type: string
                       description: CPF ou CNPJ do cliente.
                       example: 123.456.789-01
+                allowCoupons: 
+                  type: boolean
+                  default: false
+                  example: false
+                  description: Se verdadeiro cupons podem ser usados na billing
+                coupons: 
+                  type: array
+                  description: Lista de cupons disponíveis para resem usados com a billing
+                  example: ['ABKT10', "ABKT5", "PROMO10"]
+                  default: []
+                  maxItems: 50
+                  items:
+                    type: string
+
               required: ['frequency', 'methods', 'products', 'returnUrl', 'completionUrl']
               additionalProperties: false
       responses:
@@ -282,7 +296,7 @@ paths:
                   data:
                     $ref: '#/components/schemas/Billing'
                   error:
-                    type: null
+                    type: 'null'
         '401':
           description: Não autorizado. Falha na autenticação.
           content:
@@ -314,7 +328,7 @@ paths:
                     items:
                       $ref: '#/components/schemas/Billing'
                   error:
-                    type: null
+                    type: 'null'
         '401':
           description: Não autorizado. Falha na autenticação.
           content:
@@ -386,7 +400,7 @@ paths:
                   data:
                     $ref: '#/components/schemas/PixQRCode'
                   error:
-                    type: null
+                    type: 'null'
         '401':
           description: Não autorizado. Falha na autenticação.
           content:
@@ -425,7 +439,7 @@ paths:
                         description: Data de expiração do QRCode Pix
                         example: '2025-03-25T21:50:20.772Z'
                   error:
-                    type: null
+                    type: 'null'
         '401':
           description: Não autorizado. Falha na autenticação.
           content:
@@ -472,7 +486,7 @@ paths:
                   data:
                     $ref: '#/components/schemas/PixQRCode'
                   error:
-                    type: null
+                    type: 'null'
         '401':
           description: Não autorizado. Falha na autenticação.
           content:
@@ -669,11 +683,23 @@ components:
           format: date-time
           nullable: true
           description: Data e hora da próxima cobrança, ou null para cobranças únicas.
-          example: null
+          example: 'null'
         customer:
           type: object
           nullable: true
           $ref: '#/components/schemas/Customer'
+        allowCoupons: 
+          type: boolean
+          nullable: true
+          default: false
+          description: Se verdadeiro cupons podem ser usados na billing
+        coupons: 
+          type: array
+          description: Lista de cupons disponíveis para resem usados com a billing
+          nullable: true
+          default: []
+          items:
+            type: string
       required:
         ['id', 'url', 'amount', 'status', 'devMode', 'methods', 'products', 'frequency', 'createdAt', 'updatedAt']
     PixQRCode:

--- a/pages/payment/reference.mdx
+++ b/pages/payment/reference.mdx
@@ -49,6 +49,8 @@ Uma cobrança é representada em nossa API pela seguinte estrutura:
     "completionUrl": "https://example.com/completion"
   },
   "nextBilling": null,
+  "allowCoupons": false,
+  "coupons": [],
   "createdAt": "2024-12-06T18:56:15.538Z",
   "updatedAt": "2024-12-06T18:56:15.538Z"
 }
@@ -201,6 +203,26 @@ Uma cobrança é representada em nossa API pela seguinte estrutura:
 
         `nextBilling` : <u> date-time | null. </u> <br />
         Data e hora da próxima cobrança, ou null para cobranças únicas
+    </Accordion>
+    <Accordion title="allowCoupons:">
+        ```json json {2}
+        {
+          "allowCoupons": false,
+        }
+        ```
+
+        `allowCoupons` : <u> bool | null. </u> <br />
+        Permite ou não cupons para a cobrança
+    </Accordion>
+    <Accordion title="coupons:">
+        ```json json {2}
+        {
+          "coupons": [],
+        }
+        ```
+
+        `coupons` :<u> array </u> <br />
+        Cupons permitidos na cobrança. Só são considerados os cupons se `allowCoupons` é verdadeiro.
     </Accordion>
 
 </AccordionGroup>


### PR DESCRIPTION
## Changes

Adds relevant information about `allowCoupons` attributes.

![Screenshot 2025-06-20 at 3 31 08 PM](https://github.com/user-attachments/assets/1798b210-44d5-4a8d-913e-87200a3bbfbc)
![Screenshot 2025-06-20 at 3 30 43 PM](https://github.com/user-attachments/assets/b274ea84-babf-4899-a66f-0612adcaad62)
![Screenshot 2025-06-20 at 3 30 34 PM](https://github.com/user-attachments/assets/a230c2ca-d9a9-424b-9e24-1f67341f173e)
