### PR TITLE
fix: fix typo in 'Idempotente' in introduction.mdx

### DIFF
--- a/pages/introduction.mdx
+++ b/pages/introduction.mdx
@@ -33,7 +33,7 @@ Nossa API foi construída com três princípios fundamentais:
    GET /billing/get       // Busca um pagamento específico
    ```
 
-2. **Indempotente**: Execute a mesma requisição quantas vezes precisar, sem efeitos colaterais
+2. **Idempotente**: Execute a mesma requisição quantas vezes precisar, sem efeitos colaterais
    ```javascript
    // Seguro para executar múltiplas vezes
    await abacatePay.billing.create({...});


### PR DESCRIPTION
Should be _"Idempotente"_ instead of _"I**n**dempotente"_.

https://dicionario.priberam.org/idempotente

<img width="794" height="422" alt="image" src="https://github.com/user-attachments/assets/9417ef46-c007-45fa-8af7-a026509ba190" />