### PR TITLE
docs: add 'id' attribute to store information in public-mar

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -731,6 +731,10 @@ paths:
                   data:
                     type: object
                     properties:
+                      id:
+                        type: string
+                        description: Identificador único da loja no formato store_123456
+                        example: 'store_123456'
                       name:
                         type: string
                         description: Nome da loja
@@ -744,7 +748,7 @@ paths:
                         format: date-time
                         description: Data de criação da loja
                         example: '2024-12-06T18:53:31.756Z'
-                    required: ['name', 'website', 'createdAt']
+                    required: ['id', 'name', 'website', 'createdAt']
                     additionalProperties: false
                   error:
                     type: 'null'

--- a/pages/trustMRR/reference.mdx
+++ b/pages/trustMRR/reference.mdx
@@ -15,6 +15,7 @@ Informações básicas da loja retornadas pela rota `/public-mrr/merchant-info`:
 ```json
 {
   "data": {
+    "id": "store_123456",
     "name": "Example Tech",
     "website": "https://www.example.com",
     "createdAt": "2024-12-06T18:53:31.756Z"
@@ -64,6 +65,16 @@ Dados de receita por período retornados pela rota `/public-mrr/revenue`:
 ## Atributos:
 
 <AccordionGroup>
+  <Accordion title="id:">
+        ```json {2}
+        {
+          "id": "store_123456",
+        } 
+        ```
+
+        `id` : <u> string. </u> <br />
+        Identificador único da loja
+    </Accordion>
     <Accordion title="name:">
         ```json {3}
         {
@@ -95,7 +106,7 @@ Dados de receita por período retornados pela rota `/public-mrr/revenue`:
         Data de criação da loja
     </Accordion>
     <Accordion title="mrr:">
-        ```json {3}
+        ```json {4}
         {
           "mrr": 0,
         } 
@@ -105,7 +116,7 @@ Dados de receita por período retornados pela rota `/public-mrr/revenue`:
         Receita recorrente mensal em centavos. Valor 0 indica que não há receita recorrente no momento.
     </Accordion>
     <Accordion title="totalActiveSubscriptions:">
-        ```json {4}
+        ```json {5}
         {
           "totalActiveSubscriptions": 0,
         } 


### PR DESCRIPTION
## Summary
We now support showing the merchant id in the public mrr plugin. This PR allows our customers to be aware of that.

## Related Issue

Closes (N/A)

## Why
What problem does this solve?

## What changed
- Now the API returns the `id` property in the merchant info

## Breaking changes
- [ ] Yes
- [x] No

## Checklist
- [x] Docs updated
- [x] CI passing
- [x] I followed the CONTRIBUTING guidelines
- [x] I added or updated tests (if applicable)

## Additional context

The `id` examples are properly defined in the request/response schemas:

<img width="1624" height="1061" alt="Screenshot 2026-02-12 at 10 48 33" src="https://github.com/user-attachments/assets/8c68d393-1c15-45df-bbd9-ab52b8f06361" />

