### PR TITLE
docs: remove daily billing cycle from subscription documentation

### DIFF
--- a/pages/glossario.mdx
+++ b/pages/glossario.mdx
@@ -72,7 +72,6 @@ Também chamada de **Item** na API, é um plano de cobrança recorrente onde o c
 
 ### Cycle (Ciclo)
 Frequência de cobrança de uma assinatura:
-- **DAILY**: Diária
 - **WEEKLY**: Semanal  
 - **MONTHLY**: Mensal
 - **YEARLY**: Anual

--- a/pages/subscriptions/reference.mdx
+++ b/pages/subscriptions/reference.mdx
@@ -85,7 +85,7 @@ Use a `url` retornada para levar o cliente ao checkout e concluir o pagamento.
 
 ## Ciclo de cobrança
 
-Definido no produto ao criar na loja. Valores: **MONTHLY**, **YEARLY**, **WEEKLY**, **DAILY**.
+Definido no produto ao criar na loja. Valores: **MONTHLY**, **YEARLY**, **WEEKLY**.
 
 ## Status
 


### PR DESCRIPTION
## Summary
- Updated the glossary and reference pages to remove the **DAILY** billing cycle option, streamlining the available frequency options to **WEEKLY**, **MONTHLY**, and **YEARLY**.

## Related Issue

Closes (N/A)

## Why
What problem does this solve?

## What changed
- 
- 
- 

## Breaking changes
- [ ] Yes
- [x] No

## Checklist
- [x] Docs updated
- [x] CI passing
- [x] I followed the CONTRIBUTING guidelines
- [x] I added or updated tests (if applicable)

## Additional context

Add any other context or screenshots here.
