### PR TITLE
docs: update webhook payload structure for subscription events

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -24,183 +24,216 @@
     }
   },
   "navigation": {
-    "tabs": [
+    "versions": [
       {
-        "tab": "Bem-vindo",
-        "pages": ["pages/start/welcome"]
-      },
-      {
-        "tab": "Comece aqui",
-        "groups": [
+        "version": "v1",
+        "tag": "Current",
+        "tabs": [
           {
-            "group": "Comece aqui",
-            "pages": [
-              "pages/start/introduction",
-              "pages/start/quickstart",
-              "pages/devmode",
-              "pages/authentication",
-              "pages/webhooks",
-              "pages/glossario",
-              "pages/production"
+            "tab": "Comece aqui",
+            "groups": [
+              {
+                "group": "Introdução",
+                "pages": [
+                  "pages/v1/introduction"
+                ]
+              },
+              {
+                "group": "Webhooks",
+                "pages": [
+                  "pages/v1/webhooks"
+                ]
+              }
             ]
+          },
+          {
+            "tab": "API Reference",
+            "openapi": "openapi-v1.yaml"
           }
         ]
       },
       {
-        "tab": "Documentação",
-        "groups": [
+        "version": "v2",
+        "tag": "Beta",
+        "tabs": [
           {
-            "group": "Cobrar com Checkout",
-            "pages": ["pages/payment/reference", "pages/payment/create", "pages/payment/list", "pages/payment/one"]
+            "tab": "Bem-vindo",
+            "pages": ["pages/start/welcome"]
           },
           {
-            "group": "Links de pagamento",
-            "pages": [
-              "pages/payment-links/reference",
-              "pages/payment-links/create",
-              "pages/payment-links/list",
-              "pages/payment-links/one"
+            "tab": "Comece aqui",
+            "groups": [
+              {
+                "group": "Comece aqui",
+                "pages": [
+                  "pages/start/introduction",
+                  "pages/start/quickstart",
+                  "pages/devmode",
+                  "pages/authentication",
+                  "pages/webhooks",
+                  "pages/glossario",
+                  "pages/production"
+                ]
+              }
             ]
           },
           {
-            "group": "Clientes",
-            "pages": [
-              "pages/client/reference",
-              "pages/client/create",
-              "pages/client/list",
-              "pages/client/get",
-              "pages/client/delete"
+            "tab": "Documentação",
+            "groups": [
+              {
+                "group": "Cobrar com Checkout",
+                "pages": ["pages/payment/reference", "pages/payment/create", "pages/payment/list", "pages/payment/one"]
+              },
+              {
+                "group": "Links de pagamento",
+                "pages": [
+                  "pages/payment-links/reference",
+                  "pages/payment-links/create",
+                  "pages/payment-links/list",
+                  "pages/payment-links/one"
+                ]
+              },
+              {
+                "group": "Clientes",
+                "pages": [
+                  "pages/client/reference",
+                  "pages/client/create",
+                  "pages/client/list",
+                  "pages/client/get",
+                  "pages/client/delete"
+                ]
+              },
+              {
+                "group": "Checkout Transparente",
+                "pages": [
+                  "pages/pix-qrcode/reference",
+                  "pages/pix-qrcode/create",
+                  "pages/pix-qrcode/list",
+                  "pages/pix-qrcode/simulate-payment",
+                  "pages/pix-qrcode/check"
+                ]
+              },
+              {
+                "group": "Cupons",
+                "pages": [
+                  "pages/coupons/reference",
+                  "pages/coupons/create",
+                  "pages/coupons/list",
+                  "pages/coupons/get",
+                  "pages/coupons/delete",
+                  "pages/coupons/toggle"
+                ]
+              },
+              {
+                "group": "Produtos",
+                "pages": [
+                  "pages/products/reference",
+                  "pages/products/create",
+                  "pages/products/list",
+                  "pages/products/get",
+                  "pages/products/delete"
+                ]
+              },
+              {
+                "group": "Assinaturas",
+                "pages": ["pages/subscriptions/reference", "pages/subscriptions/create", "pages/subscriptions/list"]
+              },
+              {
+                "group": "Saques",
+                "pages": ["pages/payouts/reference", "pages/payouts/create", "pages/payouts/get", "pages/payouts/list"]
+              },
+              {
+                "group": "PIX",
+                "pages": ["pages/pix/reference", "pages/pix/create", "pages/pix/get", "pages/pix/list"]
+              },
+              {
+                "group": "Loja",
+                "pages": ["pages/store/reference", "pages/store/get"]
+              },
+              {
+                "group": "Public MRR",
+                "pages": ["pages/trustMRR/reference", "pages/trustMRR/mrr", "pages/trustMRR/get", "pages/trustMRR/list"]
+              }
             ]
           },
           {
-            "group": "Checkout Transparente",
-            "pages": [
-              "pages/pix-qrcode/reference",
-              "pages/pix-qrcode/create",
-              "pages/pix-qrcode/list",
-              "pages/pix-qrcode/simulate-payment",
-              "pages/pix-qrcode/check"
+            "tab": "SDKs",
+            "groups": [
+              {
+                "group": "SDKs",
+                "pages": [
+                  "pages/sdks/sdks",
+                  "pages/sdks/nodejs",
+                  "pages/sdks/python",
+                  "pages/sdks/java",
+                  "pages/sdks/php",
+                  "pages/sdks/ruby",
+                  "pages/sdks/go",
+                  "pages/sdks/rust",
+                  "pages/sdks/kotlin",
+                  "pages/sdks/swift"
+                ]
+              }
             ]
           },
           {
-            "group": "Cupons",
-            "pages": [
-              "pages/coupons/reference",
-              "pages/coupons/create",
-              "pages/coupons/list",
-              "pages/coupons/get",
-              "pages/coupons/delete",
-              "pages/coupons/toggle"
+            "tab": "CLI",
+            "groups": [
+              {
+                "group": "CLI",
+                "pages": [
+                  "pages/cli/overview",
+                  "pages/cli/flags",
+                  "pages/cli/auth",
+                  "pages/cli/payments",
+                  "pages/cli/webhooks",
+                  "pages/cli/utils",
+                  "pages/cli/cases"
+                ]
+              }
             ]
           },
           {
-            "group": "Produtos",
-            "pages": [
-              "pages/products/reference",
-              "pages/products/create",
-              "pages/products/list",
-              "pages/products/get",
-              "pages/products/delete"
+            "tab": "AI",
+            "groups": [
+              {
+                "group": "AI",
+                "pages": ["pages/ai/overview"]
+              }
             ]
           },
           {
-            "group": "Assinaturas",
-            "pages": ["pages/subscriptions/reference", "pages/subscriptions/create", "pages/subscriptions/list"]
+            "tab": "Ecossistema",
+            "groups": [
+              {
+                "group": "Ecossistema",
+                "pages": [
+                  "pages/ecosystem/ecosystem",
+                  "pages/ecosystem/theme",
+                  "pages/ecosystem/rest",
+                  "pages/ecosystem/types",
+                  "pages/ecosystem/types-go",
+                  "pages/ecosystem/eslint",
+                  "pages/ecosystem/typebox",
+                  "pages/ecosystem/zod"
+                ]
+              }
+            ]
           },
           {
-            "group": "Saques",
-            "pages": ["pages/payouts/reference", "pages/payouts/create", "pages/payouts/get", "pages/payouts/list"]
+            "tab": "HTTP",
+            "groups": [
+              {
+                "group": "HTTP",
+                "pages": ["pages/http/overview", "pages/http/postman", "pages/http/bruno"]
+              }
+            ]
           },
           {
-            "group": "PIX",
-            "pages": ["pages/pix/reference", "pages/pix/create", "pages/pix/get", "pages/pix/list"]
-          },
-          {
-            "group": "Loja",
-            "pages": ["pages/store/reference", "pages/store/get"]
-          },
-          {
-            "group": "Public MRR",
-            "pages": ["pages/trustMRR/reference", "pages/trustMRR/mrr", "pages/trustMRR/get", "pages/trustMRR/list"]
+            "tab": "Changelog",
+            "pages": ["pages/changelog/index"]
           }
         ]
-      },
-      {
-        "tab": "SDKs",
-        "groups": [
-          {
-            "group": "SDKs",
-            "pages": [
-              "pages/sdks/sdks",
-              "pages/sdks/nodejs",
-              "pages/sdks/python",
-              "pages/sdks/java",
-              "pages/sdks/php",
-              "pages/sdks/ruby",
-              "pages/sdks/go",
-              "pages/sdks/rust",
-              "pages/sdks/kotlin",
-              "pages/sdks/swift"
-            ]
-          }
-        ]
-      },
-      {
-        "tab": "CLI",
-        "groups": [
-          {
-            "group": "CLI",
-            "pages": [
-              "pages/cli/overview",
-              "pages/cli/flags",
-              "pages/cli/auth",
-              "pages/cli/payments",
-              "pages/cli/webhooks",
-              "pages/cli/utils",
-              "pages/cli/cases"
-            ]
-          }
-        ]
-      },
-      {
-        "tab": "AI",
-        "groups": [
-          {
-            "group": "AI",
-            "pages": ["pages/ai/overview"]
-          }
-        ]
-      },
-      {
-        "tab": "Ecossistema",
-        "groups": [
-          {
-            "group": "Ecossistema",
-            "pages": [
-              "pages/ecosystem/ecosystem",
-              "pages/ecosystem/theme",
-              "pages/ecosystem/rest",
-              "pages/ecosystem/types",
-              "pages/ecosystem/types-go",
-              "pages/ecosystem/eslint",
-              "pages/ecosystem/typebox",
-              "pages/ecosystem/zod"
-            ]
-          }
-        ]
-      },
-      {
-        "tab": "HTTP",
-        "groups": [
-          {
-            "group": "HTTP",
-            "pages": ["pages/http/overview", "pages/http/postman", "pages/http/bruno"]
-          }
-        ]
-      },
-      {
-        "tab": "Changelog",
-        "pages": ["pages/changelog/index"]
       }
     ]
   },

--- a/docs.json
+++ b/docs.json
@@ -24,253 +24,183 @@
     }
   },
   "navigation": {
-    "versions": [
+    "tabs": [
       {
-        "version": "v1",
-        "tag": "Current",
-        "tabs": [
+        "tab": "Bem-vindo",
+        "pages": ["pages/start/welcome"]
+      },
+      {
+        "tab": "Comece aqui",
+        "groups": [
           {
-            "tab": "Comece aqui",
-            "groups": [
-              {
-                "group": "Introdução",
-                "pages": [
-                  "pages/v1/introduction"
-                ]
-              },
-              {
-                "group": "Webhooks",
-                "pages": [
-                  "pages/v1/webhooks"
-                ]
-              }
+            "group": "Comece aqui",
+            "pages": [
+              "pages/start/introduction",
+              "pages/start/quickstart",
+              "pages/devmode",
+              "pages/authentication",
+              "pages/webhooks",
+              "pages/glossario",
+              "pages/production"
             ]
-          },
-          {
-            "tab": "API Reference",
-            "openapi": "openapi-v1.yaml"
           }
         ]
       },
       {
-        "version": "v2",
-        "tag": "Beta",
-        "tabs": [
+        "tab": "Documentação",
+        "groups": [
           {
-            "tab": "Bem-vindo",
+            "group": "Cobrar com Checkout",
+            "pages": ["pages/payment/reference", "pages/payment/create", "pages/payment/list", "pages/payment/one"]
+          },
+          {
+            "group": "Links de pagamento",
             "pages": [
-              "pages/start/welcome"
+              "pages/payment-links/reference",
+              "pages/payment-links/create",
+              "pages/payment-links/list",
+              "pages/payment-links/one"
             ]
           },
           {
-            "tab": "Comece aqui",
-            "groups": [
-              {
-                "group": "Comece aqui",
-                "pages": [
-                  "pages/start/introduction",
-                  "pages/start/quickstart",
-                  "pages/devmode",
-                  "pages/authentication",
-                  "pages/webhooks",
-                  "pages/glossario",
-                  "pages/production"
-                ]
-              }
-            ]
-          },
-          {
-            "tab": "Documentação",
-            "groups": [
-              {
-                "group": "Produtos",
-                "pages": [
-                  "pages/products/reference",
-                  "pages/products/create",
-                  "pages/products/list",
-                  "pages/products/get",
-                  "pages/products/delete"
-                ]
-              },
-              {
-                "group": "Clientes",
-                "pages": [
-                  "pages/client/reference",
-                  "pages/client/create",
-                  "pages/client/list",
-                  "pages/client/get",
-                  "pages/client/delete"
-                ]
-              },
-              {
-                "group": "Cupons",
-                "pages": [
-                  "pages/coupons/reference",
-                  "pages/coupons/create",
-                  "pages/coupons/list",
-                  "pages/coupons/get",
-                  "pages/coupons/delete",
-                  "pages/coupons/toggle"
-                ]
-              },
-              {
-                "group": "Checkouts",
-                "pages": [
-                  "pages/payment/reference",
-                  "pages/payment/create",
-                  "pages/payment/list",
-                  "pages/payment/one"
-                ]
-              },
-              {
-                "group": "Links de pagamento",
-                "pages": [
-                  "pages/payment-links/reference",
-                  "pages/payment-links/create",
-                  "pages/payment-links/list",
-                  "pages/payment-links/one"
-                ]
-              },
-              {
-                "group": "Checkout Transparente",
-                "pages": [
-                  "pages/pix-qrcode/reference",
-                  "pages/pix-qrcode/create",
-                  "pages/pix-qrcode/list",
-                  "pages/pix-qrcode/simulate-payment",
-                  "pages/pix-qrcode/check"
-                ]
-              },
-              {
-                "group": "Assinaturas",
-                "pages": [
-                  "pages/subscriptions/reference",
-                  "pages/subscriptions/create",
-                  "pages/subscriptions/list"
-                ]
-              },
-              {
-                "group": "Saques",
-                "pages": [
-                  "pages/payouts/reference",
-                  "pages/payouts/create",
-                  "pages/payouts/get",
-                  "pages/payouts/list"
-                ]
-              },
-              {
-                "group": "PIX",
-                "pages": [
-                  "pages/pix/reference",
-                  "pages/pix/create",
-                  "pages/pix/get",
-                  "pages/pix/list"
-                ]
-              },
-              {
-                "group": "Loja",
-                "pages": [
-                  "pages/store/reference",
-                  "pages/store/get"
-                ]
-              },
-              {
-                "group": "Public MRR",
-                "pages": [
-                  "pages/trustMRR/reference",
-                  "pages/trustMRR/mrr",
-                  "pages/trustMRR/get",
-                  "pages/trustMRR/list"
-                ]
-              }
-            ]
-          },
-          {
-            "tab": "SDKs",
-            "groups": [
-              {
-                "group": "SDKs",
-                "pages": [
-                  "pages/sdks/sdks",
-                  "pages/sdks/nodejs",
-                  "pages/sdks/python",
-                  "pages/sdks/java",
-                  "pages/sdks/php",
-                  "pages/sdks/ruby",
-                  "pages/sdks/go",
-                  "pages/sdks/rust",
-                  "pages/sdks/kotlin",
-                  "pages/sdks/swift"
-                ]
-              }
-            ]
-          },
-          {
-            "tab": "CLI",
-            "groups": [
-              {
-                "group": "CLI",
-                "pages": [
-                  "pages/cli/overview",
-                  "pages/cli/flags",
-                  "pages/cli/auth",
-                  "pages/cli/payments",
-                  "pages/cli/webhooks",
-                  "pages/cli/utils",
-                  "pages/cli/cases"
-                ]
-              }
-            ]
-          },
-          {
-            "tab": "AI",
-            "groups": [
-              {
-                "group": "AI",
-                "pages": [
-                  "pages/ai/overview"
-                ]
-              }
-            ]
-          },
-          {
-            "tab": "Ecossistema",
-            "groups": [
-              {
-                "group": "Ecossistema",
-                "pages": [
-                  "pages/ecosystem/ecosystem",
-                  "pages/ecosystem/theme",
-                  "pages/ecosystem/rest",
-                  "pages/ecosystem/types",
-                  "pages/ecosystem/types-go",
-                  "pages/ecosystem/eslint",
-                  "pages/ecosystem/typebox",
-                  "pages/ecosystem/zod"
-                ]
-              }
-            ]
-          },
-          {
-            "tab": "HTTP",
-            "groups": [
-              {
-                "group": "HTTP",
-                "pages": [
-                  "pages/http/overview",
-                  "pages/http/postman",
-                  "pages/http/bruno"
-                ]
-              }
-            ]
-          },
-          {
-            "tab": "Changelog",
+            "group": "Clientes",
             "pages": [
-              "pages/changelog/index"
+              "pages/client/reference",
+              "pages/client/create",
+              "pages/client/list",
+              "pages/client/get",
+              "pages/client/delete"
+            ]
+          },
+          {
+            "group": "Checkout Transparente",
+            "pages": [
+              "pages/pix-qrcode/reference",
+              "pages/pix-qrcode/create",
+              "pages/pix-qrcode/list",
+              "pages/pix-qrcode/simulate-payment",
+              "pages/pix-qrcode/check"
+            ]
+          },
+          {
+            "group": "Cupons",
+            "pages": [
+              "pages/coupons/reference",
+              "pages/coupons/create",
+              "pages/coupons/list",
+              "pages/coupons/get",
+              "pages/coupons/delete",
+              "pages/coupons/toggle"
+            ]
+          },
+          {
+            "group": "Produtos",
+            "pages": [
+              "pages/products/reference",
+              "pages/products/create",
+              "pages/products/list",
+              "pages/products/get",
+              "pages/products/delete"
+            ]
+          },
+          {
+            "group": "Assinaturas",
+            "pages": ["pages/subscriptions/reference", "pages/subscriptions/create", "pages/subscriptions/list"]
+          },
+          {
+            "group": "Saques",
+            "pages": ["pages/payouts/reference", "pages/payouts/create", "pages/payouts/get", "pages/payouts/list"]
+          },
+          {
+            "group": "PIX",
+            "pages": ["pages/pix/reference", "pages/pix/create", "pages/pix/get", "pages/pix/list"]
+          },
+          {
+            "group": "Loja",
+            "pages": ["pages/store/reference", "pages/store/get"]
+          },
+          {
+            "group": "Public MRR",
+            "pages": ["pages/trustMRR/reference", "pages/trustMRR/mrr", "pages/trustMRR/get", "pages/trustMRR/list"]
+          }
+        ]
+      },
+      {
+        "tab": "SDKs",
+        "groups": [
+          {
+            "group": "SDKs",
+            "pages": [
+              "pages/sdks/sdks",
+              "pages/sdks/nodejs",
+              "pages/sdks/python",
+              "pages/sdks/java",
+              "pages/sdks/php",
+              "pages/sdks/ruby",
+              "pages/sdks/go",
+              "pages/sdks/rust",
+              "pages/sdks/kotlin",
+              "pages/sdks/swift"
             ]
           }
         ]
+      },
+      {
+        "tab": "CLI",
+        "groups": [
+          {
+            "group": "CLI",
+            "pages": [
+              "pages/cli/overview",
+              "pages/cli/flags",
+              "pages/cli/auth",
+              "pages/cli/payments",
+              "pages/cli/webhooks",
+              "pages/cli/utils",
+              "pages/cli/cases"
+            ]
+          }
+        ]
+      },
+      {
+        "tab": "AI",
+        "groups": [
+          {
+            "group": "AI",
+            "pages": ["pages/ai/overview"]
+          }
+        ]
+      },
+      {
+        "tab": "Ecossistema",
+        "groups": [
+          {
+            "group": "Ecossistema",
+            "pages": [
+              "pages/ecosystem/ecosystem",
+              "pages/ecosystem/theme",
+              "pages/ecosystem/rest",
+              "pages/ecosystem/types",
+              "pages/ecosystem/types-go",
+              "pages/ecosystem/eslint",
+              "pages/ecosystem/typebox",
+              "pages/ecosystem/zod"
+            ]
+          }
+        ]
+      },
+      {
+        "tab": "HTTP",
+        "groups": [
+          {
+            "group": "HTTP",
+            "pages": ["pages/http/overview", "pages/http/postman", "pages/http/bruno"]
+          }
+        ]
+      },
+      {
+        "tab": "Changelog",
+        "pages": ["pages/changelog/index"]
       }
     ]
   },

--- a/docs.json
+++ b/docs.json
@@ -34,15 +34,11 @@
             "groups": [
               {
                 "group": "Introdução",
-                "pages": [
-                  "pages/v1/introduction"
-                ]
+                "pages": ["pages/v1/introduction"]
               },
               {
                 "group": "Webhooks",
-                "pages": [
-                  "pages/v1/webhooks"
-                ]
+                "pages": ["pages/v1/webhooks"]
               }
             ]
           },

--- a/pages/changelog/index.mdx
+++ b/pages/changelog/index.mdx
@@ -14,6 +14,47 @@ Feedbacks também são bem-vindos no nosso Discord (#dev).
 ## Atualizações Recentes
 
 
+<Update label="19 de Mar, 2026">
+## Webhooks de Assinatura: novo campo `checkout` no payload
+
+Os eventos de assinatura (`subscription.completed`, `subscription.renewed`, `subscription.cancelled`) passam a retornar um novo campo **`checkout`** dentro de `data`, contendo o objeto completo do checkout associado à cobrança.
+
+**O que mudou:**
+
+- Adicionado campo `checkout` em `data` com os detalhes do checkout associado à cobrança (id, url, amount, items, status, methods, etc.)
+- Adicionado campo `id` no nível raiz do payload (identificador único do log do webhook)
+
+**Estrutura anterior:**
+```json
+{
+  "event": "subscription.completed",
+  "data": {
+    "subscription": { ... },
+    "customer": { ... },
+    "payment": { ... },
+    "payerInformation": { ... }
+  }
+}
+```
+
+**Nova estrutura:**
+```json
+{
+  "id": "log_abc123xyz",
+  "event": "subscription.completed",
+  "data": {
+    "subscription": { ... },
+    "customer": { ... },
+    "payment": { ... },
+    "payerInformation": { ... },
+    "checkout": { ... }
+  }
+}
+```
+
+---
+</Update>
+
 <Update label="6 de Mar, 2026">
 ## Nova versão da API
 

--- a/pages/webhooks.mdx
+++ b/pages/webhooks.mdx
@@ -218,6 +218,7 @@ Todos os webhooks v2 compartilham o mesmo formato de payload:
 
 ```json
 {
+  "id": "log_abc123xyz",
   "event": "checkout.completed",
   "apiVersion": 2,
   "devMode": false,
@@ -650,12 +651,13 @@ Todos os webhooks v2 compartilham o mesmo formato de payload:
 
     ```json
     {
+      "id": "log_taQArRTApemxwcbw5EJeF3hS",
       "event": "subscription.completed",
       "apiVersion": 2,
       "devMode": false,
       "data": {
         "subscription": {
-          "id": "sub_abc123",
+          "id": "subs_tAFqDWBhcEYTjQh2K0ZYDHau",
           "amount": 2990,
           "currency": "BRL",
           "method": "CARD",
@@ -667,23 +669,23 @@ Todos os webhooks v2 compartilham o mesmo formato de payload:
           "cancelPolicy": null,
           "cancelledDueTo": null
         },
-        "payment": {
-          "id": "char_xyz789",
-          "externalId": "pedido-456",
-          "amount": 5000,
-          "paidAmount": 5000,
-          "platformFee": 50,
-          "status": "PAID",
-          "methods": ["PIX"],
-          "receiptUrl": "https://app.abacatepay.com/receipt/...",
-          "createdAt": "2024-12-06T19:00:00.000Z",
-          "updatedAt": "2024-12-06T19:00:05.000Z"
-        },
         "customer": {
           "id": "cust_def456",
           "name": "Maria Santos",
           "email": "maria@exemplo.com",
           "taxId": "12.***.***/0001-**"
+        },
+        "payment": {
+          "id": "char_xyz789",
+          "externalId": "pedido-456",
+          "amount": 2990,
+          "paidAmount": 2990,
+          "platformFee": 100,
+          "status": "PAID",
+          "methods": ["CARD"],
+          "receiptUrl": "https://app.abacatepay.com/receipt/...",
+          "createdAt": "2024-12-06T20:00:00.000Z",
+          "updatedAt": "2024-12-06T20:00:05.000Z"
         },
         "payerInformation": {
           "method": "CARD",
@@ -692,6 +694,22 @@ Todos os webhooks v2 compartilham o mesmo formato de payload:
             "brand": "VISA"
           }
         },
+        "checkout": {
+          "id": "bill_jskd3TMfScHZDJe5NSZjTmQ4",
+          "externalId": null,
+          "url": "https://app.abacatepay.com/pay/bill_jskd3TMfScHZDJe5NSZjTmQ4",
+          "amount": 2990,
+          "paidAmount": 2990,
+          "platformFee": 100,
+          "frequency": "SUBSCRIPTION",
+          "items": [{ "id": "prod_bx4BstRWhQ2SUcKsPt4c6pmq", "quantity": 1 }],
+          "status": "PAID",
+          "methods": ["CARD"],
+          "customerId": "cust_def456",
+          "receiptUrl": "https://app.abacatepay.com/receipt/...",
+          "createdAt": "2024-12-06T19:59:57.819Z",
+          "updatedAt": "2024-12-06T20:00:05.000Z"
+        }
       }
     }
     ```
@@ -702,40 +720,41 @@ Todos os webhooks v2 compartilham o mesmo formato de payload:
 
     ```json
     {
-      "event": "subscription.completed",
+      "id": "log_abc123xyz",
+      "event": "subscription.renewed",
       "apiVersion": 2,
       "devMode": false,
       "data": {
         "subscription": {
-          "id": "sub_abc123",
+          "id": "subs_tAFqDWBhcEYTjQh2K0ZYDHau",
           "amount": 2990,
           "currency": "BRL",
           "method": "CARD",
-          "status": "CANCELLED",
+          "status": "ACTIVE",
           "frequency": "MONTHLY",
           "createdAt": "2024-12-06T20:00:00.000Z",
-          "updatedAt": "2024-12-06T20:00:05.000Z",
+          "updatedAt": "2025-01-06T20:00:05.000Z",
           "canceledAt": null,
           "cancelPolicy": null,
           "cancelledDueTo": null
-        },
-        "payment": {
-          "id": "char_xyz789",
-          "externalId": "pedido-456",
-          "amount": 5000,
-          "paidAmount": 5000,
-          "platformFee": 50,
-          "status": "PAID",
-          "methods": ["PIX"],
-          "receiptUrl": "https://app.abacatepay.com/receipt/...",
-          "createdAt": "2024-12-06T19:00:00.000Z",
-          "updatedAt": "2024-12-06T19:00:05.000Z"
         },
         "customer": {
           "id": "cust_def456",
           "name": "Maria Santos",
           "email": "maria@exemplo.com",
           "taxId": "12.***.***/0001-**"
+        },
+        "payment": {
+          "id": "char_xyz789",
+          "externalId": "pedido-456",
+          "amount": 2990,
+          "paidAmount": 2990,
+          "platformFee": 100,
+          "status": "PAID",
+          "methods": ["CARD"],
+          "receiptUrl": "https://app.abacatepay.com/receipt/...",
+          "createdAt": "2025-01-06T20:00:00.000Z",
+          "updatedAt": "2025-01-06T20:00:05.000Z"
         },
         "payerInformation": {
           "method": "CARD",
@@ -744,6 +763,22 @@ Todos os webhooks v2 compartilham o mesmo formato de payload:
             "brand": "VISA"
           }
         },
+        "checkout": {
+          "id": "bill_renewxyz789",
+          "externalId": null,
+          "url": "https://app.abacatepay.com/pay/bill_renewxyz789",
+          "amount": 2990,
+          "paidAmount": 2990,
+          "platformFee": 100,
+          "frequency": "SUBSCRIPTION",
+          "items": [{ "id": "prod_bx4BstRWhQ2SUcKsPt4c6pmq", "quantity": 1 }],
+          "status": "PAID",
+          "methods": ["CARD"],
+          "customerId": "cust_def456",
+          "receiptUrl": "https://app.abacatepay.com/receipt/...",
+          "createdAt": "2025-01-06T19:59:57.819Z",
+          "updatedAt": "2025-01-06T20:00:05.000Z"
+        }
       }
     }
     ```
@@ -754,12 +789,13 @@ Todos os webhooks v2 compartilham o mesmo formato de payload:
 
     ```json
     {
-      "event": "subscription.completed",
+      "id": "log_abc123xyz",
+      "event": "subscription.cancelled",
       "apiVersion": 2,
       "devMode": false,
       "data": {
         "subscription": {
-          "id": "sub_abc123",
+          "id": "subs_tAFqDWBhcEYTjQh2K0ZYDHau",
           "amount": 2990,
           "currency": "BRL",
           "method": "CARD",
@@ -767,27 +803,27 @@ Todos os webhooks v2 compartilham o mesmo formato de payload:
           "frequency": "MONTHLY",
           "createdAt": "2024-12-06T20:00:00.000Z",
           "updatedAt": "2024-12-06T20:00:05.000Z",
-          "canceledAt": null,
+          "canceledAt": "2024-12-06T20:00:05.000Z",
           "cancelPolicy": null,
           "cancelledDueTo": null
-        },
-        "payment": {
-          "id": "char_xyz789",
-          "externalId": "pedido-456",
-          "amount": 5000,
-          "paidAmount": 5000,
-          "platformFee": 50,
-          "status": "PAID",
-          "methods": ["PIX"],
-          "receiptUrl": "https://app.abacatepay.com/receipt/...",
-          "createdAt": "2024-12-06T19:00:00.000Z",
-          "updatedAt": "2024-12-06T19:00:05.000Z"
         },
         "customer": {
           "id": "cust_def456",
           "name": "Maria Santos",
           "email": "maria@exemplo.com",
           "taxId": "12.***.***/0001-**"
+        },
+        "payment": {
+          "id": "char_xyz789",
+          "externalId": "pedido-456",
+          "amount": 2990,
+          "paidAmount": 2990,
+          "platformFee": 100,
+          "status": "PAID",
+          "methods": ["CARD"],
+          "receiptUrl": "https://app.abacatepay.com/receipt/...",
+          "createdAt": "2024-12-06T20:00:00.000Z",
+          "updatedAt": "2024-12-06T20:00:05.000Z"
         },
         "payerInformation": {
           "method": "CARD",
@@ -796,6 +832,22 @@ Todos os webhooks v2 compartilham o mesmo formato de payload:
             "brand": "VISA"
           }
         },
+        "checkout": {
+          "id": "bill_jskd3TMfScHZDJe5NSZjTmQ4",
+          "externalId": null,
+          "url": "https://app.abacatepay.com/pay/bill_jskd3TMfScHZDJe5NSZjTmQ4",
+          "amount": 2990,
+          "paidAmount": 2990,
+          "platformFee": 100,
+          "frequency": "SUBSCRIPTION",
+          "items": [{ "id": "prod_bx4BstRWhQ2SUcKsPt4c6pmq", "quantity": 1 }],
+          "status": "PAID",
+          "methods": ["CARD"],
+          "customerId": "cust_def456",
+          "receiptUrl": "https://app.abacatepay.com/receipt/...",
+          "createdAt": "2024-12-06T19:59:57.819Z",
+          "updatedAt": "2024-12-06T20:00:05.000Z"
+        }
       }
     }
     ```


### PR DESCRIPTION
## Summary

  Adicionado campo `checkout` nos payloads dos webhooks de assinatura e campo `id` no nível raiz de todos os webhooks.

  ## Related Issue

  Closes (N/A)

  ## Why

  Os webhooks de assinatura não expunham os dados do checkout associado à cobrança, dificultando a correlação entre
  eventos de assinatura e os checkouts gerados.

  ## What changed
  - Webhooks de assinatura (`subscription.completed`, `subscription.renewed`, `subscription.cancelled`) agora incluem
  o campo `checkout` em `data`
  - Campo `id` (identificador único do log) adicionado no nível raiz do payload
  - Documentação e exemplos de payload atualizados
  - Changelog atualizado com entry de 19 de Mar, 2026

  ## Breaking changes
  - [ ] Yes
  - [x] No

  ## Checklist
  - [x] Docs updated
  - [ ] CI passing
  - [ ] I followed the CONTRIBUTING guidelines
  - [ ] I added or updated tests (if applicable)

  ## Additional context

  O objeto `checkout` nos eventos de assinatura segue o mesmo formato do `checkout` nos eventos de checkout padrão:
  `id`, `externalId`, `url`, `amount`, `paidAmount`, `platformFee`, `frequency`, `items`, `status`, `methods`,
  `customerId`, `receiptUrl`, `createdAt`, `updatedAt`.