### PR TITLE
feat: add docs for subscription renewal failure;

### DIFF
--- a/pages/subscriptions/create.mdx
+++ b/pages/subscriptions/create.mdx
@@ -18,7 +18,11 @@ Cria um checkout de assinatura. O cliente paga uma vez e entra no ciclo de cobra
   "customerId": "cust_abc123xyz",
   "externalId": "subs-123",
   "completionUrl": "https://seusite.com/sucesso",
-  "methods": ["CARD"]
+  "methods": ["CARD"],
+  "retryPolicy": {
+    "maxRetry": 3,
+    "retryEvery": 2
+  }
 }
 ```
 

--- a/pages/subscriptions/reference.mdx
+++ b/pages/subscriptions/reference.mdx
@@ -14,16 +14,28 @@ Quando o pagamento é realizado, a assinatura se torna ativa.
 
 O `POST /subscriptions/create` usa os mesmos parâmetros do Checkout:
 
-| Parâmetro       | Obrigatório | Descrição |
-|-----------------|-------------|-----------|
-| `items`         | Sim         | Lista com **exatamente um** item (`id` e `quantity`); o produto deve ter sido criado com ciclo de assinatura |
-| `customerId`    | Não         | ID do cliente já cadastrado |
-| `externalId`    | Não         | ID da assinatura no seu sistema |
-| `returnUrl`     | Não         | URL de retorno ao clicar em "Voltar" |
-| `completionUrl` | Não         | URL após pagamento concluído |
-| `metadata`      | Não         | Metadados livres |
-| `coupons`       | Não         | Lista de cupons |
-| `methods`       | Não         | Lista de métodos (`PIX`, `CARD`). Padrão: `["CARD"]` para assinaturas |
+| Parâmetro              | Obrigatório | Descrição |
+|------------------------|-------------|-----------|
+| `items`                | Sim         | Lista com **exatamente um** item (`id` e `quantity`); o produto deve ter sido criado com ciclo de assinatura |
+| `customerId`           | Não         | ID do cliente já cadastrado |
+| `externalId`           | Não         | ID da assinatura no seu sistema |
+| `returnUrl`            | Não         | URL de retorno ao clicar em "Voltar" |
+| `completionUrl`        | Não         | URL após pagamento concluído |
+| `metadata`             | Não         | Metadados livres |
+| `coupons`              | Não         | Lista de cupons |
+| `methods`              | Não         | Lista de métodos (`PIX`, `CARD`). Padrão: `["CARD"]` para assinaturas |
+| `retryPolicy`          | Não         | Política de retentativa em caso de falha de cobrança (veja abaixo) |
+
+### retryPolicy
+
+Controla o comportamento automático de retentativas quando uma cobrança do ciclo falha (ex.: cartão sem saldo). Se não informado, os padrões são aplicados.
+
+| Campo        | Tipo    | Padrão | Min | Max | Descrição |
+|--------------|---------|--------|-----|-----|-----------|
+| `maxRetry`   | integer | `3`    | `1` | `10` | Número máximo de tentativas de cobrança antes do cancelamento automático da assinatura |
+| `retryEvery` | integer | `1`    | `1` | `30` | Dias entre cada tentativa |
+
+Após esgotar todas as tentativas sem sucesso, a assinatura é automaticamente cancelada com `cancelledDueTo: "max_payment_retries_exceeded"` e o evento `subscription.cancelled` é disparado.
 
 Exemplo (cada item só precisa de `id` e `quantity`; o ciclo vem do produto):
 
@@ -39,7 +51,11 @@ Exemplo (cada item só precisa de `id` e `quantity`; o ciclo vem do produto):
   "externalId": "subs-123",
   "returnUrl": "https://seusite.com/voltar",
   "completionUrl": "https://seusite.com/sucesso",
-  "methods": ["CARD"]
+  "methods": ["CARD"],
+  "retryPolicy": {
+    "maxRetry": 5,
+    "retryEvery": 3
+  }
 }
 ```
 
@@ -82,6 +98,39 @@ Create e list retornam o mesmo formato do Checkout (`id`, `url`, `amount`, `item
 <Tip title="Redirecione o cliente" icon="book" horizontal>
 Use a `url` retornada para levar o cliente ao checkout e concluir o pagamento.
 </Tip>
+
+### Objeto de assinatura ativa
+
+Após ativação, os endpoints de assinatura (`GET /subscriptions/get`, `GET /subscriptions/list`) retornam o objeto completo incluindo `retryPolicy`:
+
+```json
+{
+  "data": {
+    "id": "subs_abc123xyz",
+    "customerId": "cust_abc123xyz",
+    "amount": 10000,
+    "status": "ACTIVE",
+    "method": "CARD",
+    "coupons": [],
+    "devMode": false,
+    "trialDays": null,
+    "trialEndsAt": null,
+    "retryPolicy": {
+      "maxRetry": 5,
+      "retryEvery": 3
+    },
+    "createdAt": "2024-11-04T18:38:28.573Z",
+    "updatedAt": "2024-11-04T18:38:28.573Z"
+  },
+  "success": true,
+  "error": null
+}
+```
+
+| Campo                     | Tipo    | Descrição |
+|---------------------------|---------|-----------|
+| `retryPolicy.maxRetry`    | integer | Tentativas máximas antes do cancelamento automático |
+| `retryPolicy.retryEvery`  | integer | Dias entre cada tentativa |
 
 ## Ciclo de cobrança
 

--- a/pages/webhooks/events/subscriptions.mdx
+++ b/pages/webhooks/events/subscriptions.mdx
@@ -323,11 +323,46 @@ icon: 'repeat'
     </Tabs>
   </Tab>
 
+  <Tab title="subscription.payment_failed">
+    Disparado a cada falha de cobrança de um ciclo. O campo `retryNumber` indica quantas tentativas já foram feitas. Quando `retryNumber` atingir `maxRetry` (configurado em `retryPolicy` ao criar a assinatura), a assinatura é cancelada automaticamente e o evento `subscription.cancelled` é disparado logo em seguida com `cancelledDueTo: "max_payment_retries_exceeded"`.
+
+    ```json
+    {
+      "id": "log_abc123xyz",
+      "event": "subscription.payment_failed",
+      "apiVersion": 2,
+      "devMode": false,
+      "data": {
+        "subscription": {
+          "id": "subs_tAFqDWBhcEYTjQh2K0ZYDHau",
+          "amount": 2990,
+          "currency": "BRL",
+          "method": "CARD",
+          "status": "ACTIVE",
+          "frequency": "MONTHLY",
+          "retryPolicy": {
+            "maxRetry": 3,
+            "retryEvery": 2
+          },
+          "createdAt": "2024-12-06T20:00:00.000Z",
+          "updatedAt": "2025-01-06T20:00:05.000Z",
+          "canceledAt": null,
+          "cancelPolicy": null,
+          "cancelledDueTo": null
+        },
+        "installmentId": "intl_abc123xyz",
+        "installmentNumber": 2,
+        "retryNumber": 1
+      }
+    }
+    ```
+  </Tab>
+
   <Tab title="subscription.cancelled">
-    Disparado quando uma assinatura é cancelada.
+    Disparado quando uma assinatura é cancelada — seja via API ou automaticamente após esgotar todas as tentativas de cobrança. Nesse segundo caso, `cancelledDueTo` será `"max_payment_retries_exceeded"`.
 
     <Tabs>
-      <Tab title="Cartão">
+      <Tab title="Cancelamento manual">
         ```json
         {
           "id": "log_abc123xyz",
@@ -345,7 +380,7 @@ icon: 'repeat'
               "createdAt": "2024-12-06T20:00:00.000Z",
               "updatedAt": "2024-12-06T20:00:05.000Z",
               "canceledAt": "2024-12-06T20:00:05.000Z",
-              "cancelPolicy": null,
+              "cancelPolicy": "NOW",
               "cancelledDueTo": null
             },
             "customer": {
@@ -394,6 +429,44 @@ icon: 'repeat'
         ```
       </Tab>
 
+      <Tab title="Cancelamento automático (max retries)">
+        Disparado quando todas as tentativas de cobrança são esgotadas. `cancelledDueTo` identifica a causa e `cancelPolicy` é `"NOW"`, indicando que os ciclos futuros também foram cancelados.
+
+        ```json
+        {
+          "id": "log_abc123xyz",
+          "event": "subscription.cancelled",
+          "apiVersion": 2,
+          "devMode": false,
+          "data": {
+            "subscription": {
+              "id": "subs_tAFqDWBhcEYTjQh2K0ZYDHau",
+              "amount": 2990,
+              "currency": "BRL",
+              "method": "CARD",
+              "status": "CANCELLED",
+              "frequency": "MONTHLY",
+              "retryPolicy": {
+                "maxRetry": 3,
+                "retryEvery": 2
+              },
+              "createdAt": "2024-12-06T20:00:00.000Z",
+              "updatedAt": "2025-01-06T20:00:05.000Z",
+              "canceledAt": "2025-01-06T20:00:05.000Z",
+              "cancelPolicy": "NOW",
+              "cancelledDueTo": "max_payment_retries_exceeded"
+            },
+            "customer": {
+              "id": "cust_def456",
+              "name": "Maria Santos",
+              "email": "maria@exemplo.com",
+              "taxId": "12.***.***/0001-**"
+            }
+          }
+        }
+        ```
+      </Tab>
+
       <Tab title="PIX">
         ```json
         {
@@ -412,7 +485,7 @@ icon: 'repeat'
               "createdAt": "2024-12-06T20:00:00.000Z",
               "updatedAt": "2024-12-06T20:00:05.000Z",
               "canceledAt": "2024-12-06T20:00:05.000Z",
-              "cancelPolicy": null,
+              "cancelPolicy": "NOW",
               "cancelledDueTo": null
             },
             "customer": {


### PR DESCRIPTION
## Summary

Add subscription failure docs, including how to setup the settings and webhooks sent after many failed renewal attempts

## Related Issue

Closes (N/A)

## Why
What problem does this solve?

## What changed
- 
- 
- 

## Breaking changes
- [ ] Yes
- [ ] No

## Checklist
- [ ] Docs updated
- [ ] CI passing
- [ ] I followed the CONTRIBUTING guidelines
- [ ] I added or updated tests (if applicable)

## Additional context

Add any other context or screenshots here.
