### PR TITLE
fix: corrige exemplo de payload em client/create

### DIFF
--- a/pages/client/create.mdx
+++ b/pages/client/create.mdx
@@ -12,13 +12,11 @@ Cadastra um cliente para pré-preencher o checkout e reutilizar em várias cobra
 **Exemplo:**
 ```json
 {
-  "data": {
-    "email": "joao@exemplo.com",
-    "name": "João Silva",
-    "taxId": "12345678900",
-    "cellphone": "+5511999999999",
-    "zipCode": "01310-100"
-  },
+  "email": "joao@exemplo.com",
+  "name": "João Silva",
+  "taxId": "12345678900",
+  "cellphone": "+5511999999999",
+  "zipCode": "01310-100",
   "metadata": { "plano": "premium" }
 }
 ```


### PR DESCRIPTION
<!-- We appreciate this, thanks! -->
## Summary
Corrige o exemplo de payload na página `client/create`, removendo o wrapper `data` que estava incorreto.

## Related Issue
Closes #81

## Why
O exemplo JSON no card "Exemplo" envolvia os campos de entrada dentro de um objeto `data`, mas a API espera os campos direto no corpo da requisição. O wrapper `data` é usado apenas no formato de **resposta** da API, não no request, isso confundia quem seguia o exemplo ao integrar.

## What changed
- Removido o wrapper `data` do exemplo JSON em `pages/client/create.mdx`
- Campos (`email`, `name`, `taxId`, `cellphone`, `zipCode`, `metadata`) agora aparecem direto no corpo, alinhados com o exemplo de cURL já presente na mesma página

## Breaking changes
- [x] No

## Checklist
- [x] Docs updated
- [ ] CI passing
- [x] I followed the CONTRIBUTING guidelines
- [ ] I added or updated tests (if applicable)

## Additional context
Validado localmente com `mintlify dev`, a página renderiza corretamente e o card "Exemplo" agora reflete o formato de request correto, consistente com o exemplo de cURL da mesma página.