### PR TITLE
feat: add deadline in boleto method

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1031,6 +1031,7 @@ paths:
                     enum:
                       - PIX
                       - CARD
+                      - BOLETO
                   minItems: 1
                   default: ['PIX', 'CARD']
                   x-mint:
@@ -1096,6 +1097,20 @@ paths:
 
 
                     **Exemplo**: `"prod_bump456xyz"`
+                  x-mint:
+                    hidden: true
+                dueDate:
+                  type: string
+                  format: date
+                  description: >
+                    Data de vencimento do boleto no formato `YYYY-MM-DD`
+                    (ex: `"2026-08-15"`). Opcional. Só é válido quando
+                    `methods` inclui `BOLETO`; ignorado nos demais métodos.
+
+
+                    Se omitido, o vencimento padrão é de 3 dias úteis.
+                    Não pode ser data no passado. Máximo de 365 dias no futuro.
+                  example: '2026-08-15'
                   x-mint:
                     hidden: true
                 interest:
@@ -1324,6 +1339,7 @@ paths:
                     enum:
                       - PIX
                       - CARD
+                      - BOLETO
                   minItems: 1
                   default: ['PIX', 'CARD']
                   x-mint:
@@ -1363,6 +1379,20 @@ paths:
 
 
                     **Exemplo**: `"seu_id_123"`
+                  x-mint:
+                    hidden: true
+                dueDate:
+                  type: string
+                  format: date
+                  description: >
+                    Data de vencimento do boleto no formato `YYYY-MM-DD`
+                    (ex: `"2026-08-15"`). Opcional. Só é válido quando
+                    `methods` inclui `BOLETO`; ignorado nos demais métodos.
+
+
+                    Se omitido, o vencimento padrão é de 3 dias úteis.
+                    Não pode ser data no passado. Máximo de 365 dias no futuro.
+                  example: '2026-08-15'
                   x-mint:
                     hidden: true
                 interest:
@@ -1752,7 +1782,21 @@ paths:
                       description: Valor da cobrança em centavos.
                     expiresIn:
                       type: number
-                      description: PIX — expiração em segundos.
+                      description: >
+                        PIX — tempo de expiração em segundos. Não se aplica a
+                        `method: "BOLETO"` (use `dueDate`).
+                      x-mint:
+                        hidden: true
+                    dueDate:
+                      type: string
+                      format: date
+                      description: >
+                        BOLETO — data de vencimento no formato `YYYY-MM-DD`
+                        (ex: `"2026-08-15"`). Opcional. Se omitido, o vencimento
+                        padrão é de 3 dias úteis. Não pode ser data no passado.
+                        Máximo de 365 dias no futuro. Ignorado quando
+                        `method` é `PIX`.
+                      example: '2026-08-15'
                       x-mint:
                         hidden: true
                     description:
@@ -1845,18 +1889,18 @@ paths:
               example:
                 data:
                   id: bole_k8pqr2mnvx
-                  amount: 25000
+                  amount: 5000
                   status: PENDING
                   devMode: false
-                  barCode: 23793.38128 60007.827263 37000.963779 4 10010000025000
+                  barCode: 23793.38128 60007.827263 37000.963779 4 10010000005000
                   url: https://app.abacatepay.com/pay/bole_k8pqr2mnvx/boleto
                   brCode: 00020126580014BR.GOV.BCB.PIX0136d2b4e5f6-7890-abcd-ef12-34567890abcd5204000053039865802BR5914Mariana Costa6009SAO PAULO62070503***6304F1C2
                   brCodeBase64: data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAA...
                   platformFee: 250
                   receiptUrl: null
-                  expiresAt: '2024-11-07T03:00:00.000Z'
-                  createdAt: '2024-11-04T14:22:10.381Z'
-                  updatedAt: '2024-11-04T14:22:10.381Z'
+                  expiresAt: '2026-08-16T02:59:59.999Z'
+                  createdAt: '2026-07-27T14:22:10.381Z'
+                  updatedAt: '2026-07-27T14:22:10.381Z'
                   metadata:
                     faturaId: fatura-456
                     plano: pro
@@ -4221,6 +4265,14 @@ components:
             com mais de uma parcela. `null` para pagamentos à vista ou realizados
             por outros métodos (PIX, Boleto).
           example: 3
+        dueDate:
+          type: string
+          format: date
+          nullable: true
+          description: >-
+            Data de vencimento do boleto (`YYYY-MM-DD`). `null` quando não
+            foi configurada ou quando o método de pagamento não é BOLETO.
+          example: '2026-08-15'
         interest:
           nullable: true
           description: >-
@@ -4423,8 +4475,9 @@ components:
         expiresAt:
           type: string
           description: >-
-            Data de expiração da cobrança (ISO 8601). Para boleto, representa
-            a data de vencimento.
+            Data de expiração da cobrança (ISO 8601). Para boleto, corresponde
+            ao fim do dia de `dueDate` (ou do vencimento padrão de 3 dias
+            úteis, se `dueDate` não foi informado).
           example: '2024-11-07T03:00:00.000Z'
         createdAt:
           type: string
@@ -4508,7 +4561,9 @@ components:
             - $ref: '#/components/schemas/BoletoFine'
         expiresAt:
           type: string
-          description: Data de vencimento do boleto (ISO 8601).
+          description: >-
+            Data de expiração do boleto (ISO 8601), correspondente ao fim do
+            dia de `dueDate` (ou do vencimento padrão de 3 dias úteis).
           example: '2024-11-07T03:00:00.000Z'
         createdAt:
           type: string

--- a/pages/changelog/index.mdx
+++ b/pages/changelog/index.mdx
@@ -11,6 +11,52 @@ Feedbacks também são bem-vindos no nosso Discord (#dev).
 
 ## Atualizações Recentes
 
+<Update label="27 de Jul, 2026">
+## Boleto: data de vencimento customizável (`dueDate`)
+
+Agora é possível definir a data de vencimento do boleto via API. Antes o vencimento era sempre de **3 dias úteis**.
+
+**O que mudou:**
+
+- Novo campo opcional `dueDate` (`YYYY-MM-DD`) em `POST /v2/checkouts/create` e `POST /v2/transparents/create` (com `method: "BOLETO"`)
+- Se omitido, o vencimento padrão continua sendo 3 dias úteis
+- Regras: só válido com boleto; não pode ser data no passado; máximo de 365 dias no futuro
+- A resposta do checkout expõe `dueDate` (`string | null`)
+- No transparente, a resposta continua com `expiresAt` (ISO datetime no fim do dia do `dueDate`)
+
+**Exemplo — Checkout:**
+
+```json
+{
+  "methods": ["BOLETO"],
+  "dueDate": "2026-08-15",
+  "items": [{ "id": "prod_abc123", "quantity": 1 }]
+}
+```
+
+**Exemplo — Transparente:**
+
+```json
+{
+  "method": "BOLETO",
+  "data": {
+    "amount": 5000,
+    "dueDate": "2026-08-15",
+    "customer": {
+      "name": "Cliente",
+      "taxId": "11144477735",
+      "email": "cliente@email.com"
+    }
+  }
+}
+```
+
+Consulte [Data de vencimento do boleto](/pages/payment/reference#data-de-vencimento-do-boleto) e [Criar cobrança Boleto](/pages/transparents/boleto).
+
+---
+
+</Update>
+
 <Update label="9 de Jun, 2026">
 ## Saques via API v1: validação de titularidade obrigatória
 

--- a/pages/payment-links/create.mdx
+++ b/pages/payment-links/create.mdx
@@ -27,6 +27,7 @@ Cria um link de pagamento que pode ser pago por múltiplos clientes — ideal pa
 {
   "frequency": "MULTIPLE_PAYMENTS",
   "methods": ["BOLETO"],
+  "dueDate": "2026-08-15",
   "items": [
     { "id": "prod_abc123xyz", "quantity": 1 }
   ],
@@ -37,6 +38,10 @@ Cria um link de pagamento que pode ser pago por múltiplos clientes — ideal pa
 
 <Tip title="Use a url retornada" horizontal>
 Compartilhe `data.url` — cada cliente que acessar o link pode pagar de forma independente.
+</Tip>
+
+<Tip title="Vencimento do boleto" horizontal>
+Use `dueDate` (`YYYY-MM-DD`) para definir a data de vencimento. Se omitido, o padrão é 3 dias úteis. Só se aplica a `methods: ["BOLETO"]` — veja a [referência completa](/pages/payment/reference#data-de-vencimento-do-boleto).
 </Tip>
 
 <Tip title="Multa e juros no boleto" horizontal>

--- a/pages/payment/create.mdx
+++ b/pages/payment/create.mdx
@@ -46,10 +46,22 @@ Gera uma página de pagamento hospedada. Você envia os produtos; a API devolve 
 }
 ```
 
+**Exemplo com vencimento customizado (apenas BOLETO):**
+```json
+{
+  "methods": ["BOLETO"],
+  "dueDate": "2026-08-15",
+  "items": [
+    { "id": "prod_abc123xyz", "quantity": 1 }
+  ]
+}
+```
+
 **Exemplo com multa e juros (apenas BOLETO):**
 ```json
 {
   "methods": ["BOLETO"],
+  "dueDate": "2026-08-15",
   "items": [
     { "id": "prod_abc123xyz", "quantity": 1 }
   ],
@@ -60,6 +72,10 @@ Gera uma página de pagamento hospedada. Você envia os produtos; a API devolve 
 
 <Tip title="Upsell" horizontal>
 Use `upSellProductId` para oferecer um produto adicional ao cliente após a conclusão do pagamento. O produto deve ser **avulso** (sem `cycle`) e estar com status `ACTIVE`. Veja a [referência completa de upsell](/pages/payment/reference#upsell).
+</Tip>
+
+<Tip title="Vencimento do boleto" horizontal>
+Use `dueDate` (`YYYY-MM-DD`) para definir a data de vencimento. Se omitido, o padrão é 3 dias úteis. Só se aplica a `methods: ["BOLETO"]`. Veja a [referência completa](/pages/payment/reference#data-de-vencimento-do-boleto).
 </Tip>
 
 <Tip title="Multa e juros no boleto" horizontal>

--- a/pages/payment/reference.mdx
+++ b/pages/payment/reference.mdx
@@ -126,6 +126,50 @@ POST /checkouts/create
 
 O `upSellProductId` é retornado na resposta e ficará `null` caso nenhum produto de upsell tenha sido vinculado ao checkout.
 
+## Data de vencimento do boleto
+
+Para cobranças com `methods: ["BOLETO"]`, você pode definir a data de vencimento com o campo opcional `dueDate` (`YYYY-MM-DD`). Se omitido, o vencimento padrão é de **3 dias úteis**.
+
+| Campo | Tipo | Descrição |
+|---|---|---|
+| `dueDate` | `string` | Data de vencimento no formato `YYYY-MM-DD` (ex: `"2026-08-15"`). Opcional. |
+
+**Regras:**
+
+- Só é válido se `methods` incluir `BOLETO` (ignorado nos demais métodos)
+- Não pode ser data no passado
+- Máximo de 365 dias no futuro
+
+`dueDate` é a data de vencimento enviada ao provedor. Sem juros/multa, após o vencimento o boleto expira (`EXPIRED`) via webhook `PAYMENT_OVERDUE`. Com juros/multa, o boleto pode permanecer aberto para pagamento em atraso.
+
+**Exemplo:**
+```json
+POST /checkouts/create
+{
+  "methods": ["BOLETO"],
+  "dueDate": "2026-08-15",
+  "items": [
+    { "id": "prod_abc123", "quantity": 1 }
+  ]
+}
+```
+
+A resposta do checkout expõe `dueDate` (`string` ou `null`):
+
+```json
+{
+  "data": {
+    "id": "bill_abc123xyz",
+    "amount": 10000,
+    "status": "PENDING",
+    "dueDate": "2026-08-15",
+    ...
+  },
+  "success": true,
+  "error": null
+}
+```
+
 ## Multa e juros no boleto
 
 Para cobranças com `methods: ["BOLETO"]`, você pode configurar **juros por atraso** (`interest`) e **multa por atraso** (`fine`) que serão aplicados se o cliente pagar após a data de vencimento. Ambos os campos são opcionais e independentes — pode-se enviar só `interest`, só `fine`, ambos ou nenhum.
@@ -164,6 +208,7 @@ A multa é uma **cobrança única** aplicada uma vez após o vencimento.
 POST /checkouts/create
 {
   "methods": ["BOLETO"],
+  "dueDate": "2026-08-15",
   "items": [
     { "id": "prod_abc123", "quantity": 1 }
   ],
@@ -177,6 +222,7 @@ POST /checkouts/create
 POST /checkouts/create
 {
   "methods": ["BOLETO"],
+  "dueDate": "2026-08-15",
   "items": [
     { "id": "prod_abc123", "quantity": 1 }
   ],
@@ -186,7 +232,7 @@ POST /checkouts/create
 
 **Resposta:**
 
-Os mesmos objetos `interest` e `fine` constam na resposta de `GET /checkouts/get` e `GET /checkouts/list`, ou ficam `null` quando nenhum dos campos foi configurado.
+Os mesmos objetos `interest` e `fine` constam na resposta de `GET /checkouts/get` e `GET /checkouts/list`, ou ficam `null` quando nenhum dos campos foi configurado. O campo `dueDate` também é retornado (`string` ou `null`).
 
 ```json
 {
@@ -194,6 +240,7 @@ Os mesmos objetos `interest` e `fine` constam na resposta de `GET /checkouts/get
     "id": "bill_abc123xyz",
     "amount": 10000,
     "status": "PENDING",
+    "dueDate": "2026-08-15",
     "interest": { "value": 100 },
     "fine": { "value": 200, "type": "PERCENTAGE" },
     ...

--- a/pages/transparents/boleto.mdx
+++ b/pages/transparents/boleto.mdx
@@ -24,6 +24,21 @@ Cria um checkout transparente via **Boleto**. A API devolve a linha digitável (
 | `data.customer.name` | `string` | Nome completo do pagador |
 | `data.customer.taxId` | `string` | CPF ou CNPJ do pagador |
 
+### `data.dueDate` — vencimento (opcional)
+
+Data de vencimento do boleto no formato `YYYY-MM-DD` (ex: `"2026-08-15"`). Se omitido, o vencimento padrão é de **3 dias úteis**.
+
+| Campo | Tipo | Descrição |
+|---|---|---|
+| `dueDate` | `string` | Data de vencimento (`YYYY-MM-DD`). Opcional. |
+
+**Regras:**
+
+- Não pode ser data no passado
+- Máximo de 365 dias no futuro
+
+`dueDate` é a data enviada ao provedor. A resposta continua expondo `expiresAt` (ISO datetime no fim do dia do `dueDate`). Sem juros/multa, após o vencimento o boleto expira (`EXPIRED`) via webhook `PAYMENT_OVERDUE`. Com juros/multa, pode permanecer aberto para pagamento em atraso.
+
 ### `data.utm` — campanha / UTM (opcional)
 
 No **`BoletoTransparentData`** (corpo `data` com `method: "BOLETO"`), você pode incluir o mesmo bloco opcional `utm`: objeto opcional com campos opcionais `source`, `medium`, `campaign`, `term` e `content` (`string`). Valores enviados podem ser vistos no **dashboard** e **não mudam** o fluxo da cobrança.
@@ -32,7 +47,7 @@ No **`BoletoTransparentData`** (corpo `data` com `method: "BOLETO"`), você pode
 
 ## Exemplos mínimos (BOLETO)
 
-Sem `utm`:
+Sem `dueDate` (vencimento padrão de 3 dias úteis):
 
 ```json
 {
@@ -42,6 +57,23 @@ Sem `utm`:
     "customer": {
       "name": "Mariana Costa",
       "taxId": "987.654.321-00"
+    }
+  }
+}
+```
+
+Com `dueDate`:
+
+```json
+{
+  "method": "BOLETO",
+  "data": {
+    "amount": 5000,
+    "dueDate": "2026-08-15",
+    "customer": {
+      "name": "Cliente",
+      "taxId": "11144477735",
+      "email": "cliente@email.com"
     }
   }
 }
@@ -76,6 +108,7 @@ Com `utm`:
   "method": "BOLETO",
   "data": {
     "amount": 25000,
+    "dueDate": "2026-08-15",
     "description": "Fatura de serviço mensal",
     "customer": {
       "name": "Mariana Costa",
@@ -124,6 +157,7 @@ A multa é uma **cobrança única** aplicada uma vez após o vencimento.
   "method": "BOLETO",
   "data": {
     "amount": 5000,
+    "dueDate": "2026-08-15",
     "customer": {
       "name": "João Silva",
       "taxId": "123.456.789-00"
@@ -157,7 +191,7 @@ A multa é uma **cobrança única** aplicada uma vez após o vencimento.
 
 ## Resposta
 
-Os mesmos objetos `interest` e `fine` constam na resposta de `POST /transparents/create`, `GET /transparents/get` e `GET /transparents/list` (dentro do payload do boleto), ou ficam `null` quando nenhum dos campos foi configurado.
+Os mesmos objetos `interest` e `fine` constam na resposta de `POST /transparents/create`, `GET /transparents/get` e `GET /transparents/list` (dentro do payload do boleto), ou ficam `null` quando nenhum dos campos foi configurado. O campo `expiresAt` é o datetime ISO no fim do dia do `dueDate` (ou do vencimento padrão de 3 dias úteis).
 
 ```json
 {
@@ -174,9 +208,9 @@ Os mesmos objetos `interest` e `fine` constam na resposta de `POST /transparents
     "interest": { "value": 100 },
     "fine": { "value": 1000, "type": "FIXED" },
     "receiptUrl": null,
-    "expiresAt": "2024-11-07T03:00:00.000Z",
-    "createdAt": "2024-11-04T14:22:10.381Z",
-    "updatedAt": "2024-11-04T14:22:10.381Z",
+    "expiresAt": "2026-08-16T02:59:59.999Z",
+    "createdAt": "2026-07-27T14:22:10.381Z",
+    "updatedAt": "2026-07-27T14:22:10.381Z",
     "metadata": {
       "faturaId": "fatura-456",
       "plano": "pro"

--- a/pages/transparents/reference.mdx
+++ b/pages/transparents/reference.mdx
@@ -105,6 +105,8 @@ Use `POST /v2/transparents/create` com `method: "BOLETO"`. A API devolve a linha
   `data.amount` e `data.customer` (com `name` e `taxId`) são obrigatórios para boleto.
 </Card>
 
+Use `data.dueDate` (`YYYY-MM-DD`) para definir a data de vencimento. Se omitido, o padrão é **3 dias úteis**. Não pode ser data no passado; máximo de 365 dias no futuro. A resposta expõe `expiresAt` (ISO datetime no fim do dia do `dueDate`).
+
 **Exemplo de requisição:**
 
 ```json
@@ -112,7 +114,8 @@ POST /v2/transparents/create
 {
   "method": "BOLETO",
   "data": {
-    "amount": 25000,
+    "amount": 5000,
+    "dueDate": "2026-08-15",
     "description": "Fatura de serviço mensal",
     "customer": {
       "name": "Mariana Costa",
@@ -134,10 +137,10 @@ POST /v2/transparents/create
 {
   "data": {
     "id": "bole_k8pqr2mnvx",
-    "amount": 25000,
+    "amount": 5000,
     "status": "PENDING",
     "devMode": false,
-    "barCode": "23793.38128 60007.827263 37000.963779 4 10010000025000",
+    "barCode": "23793.38128 60007.827263 37000.963779 4 10010000005000",
     "url": "https://app.abacatepay.com/pay/bole_k8pqr2mnvx/boleto",
     "pix": {
       "brCode": "00020126580014BR.GOV.BCB.PIX0136d2b4e5f6-7890-abcd-ef12-34567890abcd5204000053039865802BR5913Mariana Costa6009SAO PAULO62070503***6304F1C2",
@@ -145,9 +148,9 @@ POST /v2/transparents/create
     },
     "platformFee": 250,
     "receiptUrl": null,
-    "expiresAt": "2024-11-07T03:00:00.000Z",
-    "createdAt": "2024-11-04T14:22:10.381Z",
-    "updatedAt": "2024-11-04T14:22:10.381Z",
+    "expiresAt": "2026-08-16T02:59:59.999Z",
+    "createdAt": "2026-07-27T14:22:10.381Z",
+    "updatedAt": "2026-07-27T14:22:10.381Z",
     "metadata": {
       "faturaId": "fatura-456",
       "plano": "pro"


### PR DESCRIPTION
Adiciona dueDate opcional (YYYY-MM-DD) no boleto de checkout e transparente

Se omitido, vencimento padrão de 3 dias úteis

Adicionei no changelog tbm

<img width="1192" height="791" alt="image" src="https://github.com/user-attachments/assets/e661fb59-f5ce-4a3d-b168-05df2a353bd5" />


