### PR TITLE
fix: indicação visual e target=_blank em links externos (welcome)

### DIFF
--- a/pages/start/welcome.mdx
+++ b/pages/start/welcome.mdx
@@ -219,7 +219,7 @@ mode: "custom"
     gridTemplateColumns: "repeat(auto-fit, minmax(280px, 1fr))",
     gap: "24px"
   }}>
-    <Card icon="graduation-cap" title="AbacatePay Academy" href="https://chat.abacatepay.com/academy">
+    <Card icon="graduation-cap" title="AbacatePay Academy ↗" href="https://chat.abacatepay.com/academy" target="_blank">
       Acesse o AbacatePay Academy para aprender a usar a API da AbacatePay.
     </Card>
 
@@ -227,7 +227,7 @@ mode: "custom"
       Dúvidas frequentes e termos técnicos explicados.
     </Card>
 
-    <Card icon="headset" title="Suporte" href="https://www.abacatepay.com/">
+    <Card icon="headset" title="Suporte ↗" href="https://www.abacatepay.com/" target="_blank">
       Entre em contato com o suporte da AbacatePay para ajuda com sua integração.
     </Card>
   </div>


### PR DESCRIPTION
## Summary

- Adiciona a flag `target="_blank"` aos cards que levam para links externos na página `/pages/start/welcome`.
- Adiciona o ícone visual `↗` ao título dos cards (Academy e Suporte) para sinalizar claramente a saída da documentação, conforme sugerido.
- Melhora a UX de navegação e previne perda de contexto de quem está lendo a documentação.

Resolves AbacatePay/ecosystem#41 (Issue foi aberta no repositório ecosystem, mas o código mora aqui).