### PR TITLE
fix: corrige endpoint da loja, paginação e atualiza a página de Ruby

### DIFF
--- a/pages/payouts/create.mdx
+++ b/pages/payouts/create.mdx
@@ -13,14 +13,22 @@ Saca saldo da sua conta para uma chave PIX de sua titularidade.
 **Saques vs PIX:** use **Saques** para sua própria chave PIX. Para enviar a terceiros use [Enviar PIX](/pages/pix/create).
 </Note>
 
-**Exemplo:**
+<Warning>
+  O destino é aninhado em `pix`, com as chaves `key` e `type`. Enviar
+  `pixKey`/`pixKeyType` no topo falha com `Property 'pix' is missing`, e
+  aninhar com esses nomes falha com `Property 'pix.type' is missing`.
+</Warning>
+
+**Formato aceito pela API:**
 ```json
 {
   "amount": 10000,
   "description": "Saque semanal",
   "externalId": "saque-123",
-  "pixKey": "sua-chave@email.com",
-  "pixKeyType": "EMAIL"
+  "pix": {
+    "key": "sua-chave@email.com",
+    "type": "EMAIL"
+  }
 }
 ```
 

--- a/pages/pix/create.mdx
+++ b/pages/pix/create.mdx
@@ -13,20 +13,28 @@ Envia dinheiro para qualquer chave PIX de terceiros — fornecedores, parceiros 
 **PIX vs Saques:** use **PIX** para enviar a chaves de terceiros. Para sacar para a sua própria chave use [Saques](/pages/payouts/create).
 </Note>
 
-**Exemplo:**
+<Warning>
+  O destino é aninhado em `pix`, com as chaves `key` e `type`. Enviar
+  `pixKey`/`pixKeyType` no topo falha com `Property 'pix' is missing`, e
+  aninhar com esses nomes falha com `Property 'pix.type' is missing`.
+</Warning>
+
+**Formato aceito pela API:**
 ```json
 {
   "amount": 10000,
   "description": "Pagamento fornecedor #42",
   "externalId": "pix-123",
-  "pixKey": "contato@fornecedor.com",
-  "pixKeyType": "EMAIL"
+  "pix": {
+    "key": "contato@fornecedor.com",
+    "type": "EMAIL"
+  }
 }
 ```
 
 **Tipos de chave PIX aceitos:**
 
-| `pixKeyType` | Exemplo |
+| `pix.type` | Exemplo |
 |--------------|---------|
 | `CPF` | `12345678901` |
 | `CNPJ` | `12345678000190` |

--- a/pages/reference/introduction.mdx
+++ b/pages/reference/introduction.mdx
@@ -105,22 +105,23 @@ Endpoints de listagem suportam **paginação por cursor** e **filtro por interva
 | `after` | `string` | Cursor — `publicId` do último item da página anterior |
 | `before` | `string` | Cursor — `publicId` do primeiro item da página seguinte |
 
-A resposta inclui metadados em `pagination`:
+<Warning>
+  A API **ainda não envia** o objeto `pagination` nas respostas de listagem. O
+  envelope retornado hoje é apenas `{ data, error, success }`. Para avançar,
+  use o `id` do último item da página como `after`.
+</Warning>
+
+Envelope retornado hoje:
 
 ```json
 {
   "success": true,
   "data": [ ... ],
-  "pagination": {
-    "hasMore": true,
-    "next": "cust_abc123",
-    "before": "cust_xyz789"
-  },
   "error": null
 }
 ```
 
-Para avançar, passe `after` com o valor de `pagination.next`:
+Para avançar, passe `after` com o `id` do último item recebido:
 
 ```bash
 GET /v2/customers/list?limit=20&after=cust_abc123

--- a/pages/sdks/ruby.mdx
+++ b/pages/sdks/ruby.mdx
@@ -11,6 +11,7 @@ icon: 'gem'
 ## Pré-requisitos
 
 - Ruby 3.2+
+- Gem `abacatepay-ruby` 1.2.2 ou superior
 - Uma chave de API ([criar no dashboard](https://app.abacatepay.com))
 
 ## Instalação
@@ -98,7 +99,7 @@ Todos os recursos são acessíveis pela fachada `AbacatePay.<recurso>`:
 | `coupons` | `list` `get` `create` `delete` `toggle` |
 | `checkouts` | `list` `get` `create` `refund` |
 | `payment_links` | `list` `get` `create` `refund` |
-| `subscriptions` | `list` `create` `cancel` |
+| `subscriptions` | `list` `create` `cancel` `change_plan` `record_usage` |
 | `transparents` | `list` `create` `check` `simulate_payment` `refund` |
 | `pix` | `list` `get` `send_pix` |
 | `payouts` | `list` `get` `create` |
@@ -135,16 +136,29 @@ end
 
 ## Webhooks
 
-Use `construct_event`, que verifica a assinatura **antes** de fazer o parse do corpo — é o único ponto de entrada que não permite agir sobre um payload não verificado:
+A AbacatePay usa **dois mecanismos** e a [documentação de segurança](/pages/webhooks/security) orienta usar os dois:
+
+| Mecanismo | O que garante |
+|---|---|
+| `webhookSecret` na query | autentica a **origem** |
+| Assinatura HMAC no header | integridade do **corpo** |
+
+A chave HMAC é pública e global, publicada na documentação, então a assinatura sozinha não prova origem.
 
 ```ruby
 payload   = request.body.read
 signature = request.headers['X-Webhook-Signature']
-secret    = ENV['ABACATEPAY_WEBHOOK_SECRET']
 
 begin
+  # 1. Autentica a origem com o secret definido ao criar o webhook.
+  AbacatePay::Webhooks.verify_secret!(
+    received: params[:webhookSecret],
+    expected: ENV['ABACATEPAY_WEBHOOK_SECRET']
+  )
+
+  # 2. Verifica a integridade do corpo antes de fazer o parse.
   event = AbacatePay::Webhooks.construct_event(
-    payload: payload, signature: signature, secret: secret
+    payload: payload, signature: signature
   )
 rescue AbacatePay::Webhooks::SignatureError
   return head :unauthorized
@@ -153,13 +167,66 @@ rescue AbacatePay::Webhooks::PayloadError
 end
 
 case event.type
-when 'checkout.completed' then handle_payment(event.data)
+when 'checkout.completed'          then handle_payment(event.data)
+when 'subscription.payment_failed' then handle_dunning(event.data)
 end
 ```
 
-<Tip title="Assinatura ausente também é rejeitada" horizontal>
-Header ausente, secret vazio, assinatura forjada e corpo malformado levantam erro tipado em vez de derrubar o endpoint. A comparação é feita em tempo constante.
+<Tip title="Idempotência é obrigatória" horizontal>
+A AbacatePay reentrega qualquer webhook que não responda 2xx. Guarde o `id` do evento com índice único no banco e responda 200 também para duplicatas, senão a reentrega não para.
 </Tip>
+
+<Warning>
+Em Rails, leia `request.query_parameters` em vez de `params` antes de validar. Tocar em `params` faz o framework parsear o corpo, e um corpo malformado estoura antes do seu código rodar.
+</Warning>
+
+## Boleto
+
+Boleto tem vencimento, juros e multa próprios. Valores em centavos.
+
+```ruby
+AbacatePay.checkouts.create(
+  AbacatePay::Resources::Checkouts.new(
+    methods: ['BOLETO'],
+    due_date: '2026-09-15',
+    interest: { value: 100 },
+    fine: { value: 200, type: 'PERCENTAGE' },
+    products: [
+      AbacatePay::Resources::Billings::Product.new(external_id: 'prod_abc123xyz', quantity: 1)
+    ]
+  )
+)
+```
+
+No checkout transparente, o boleto exige nome e CPF/CNPJ do pagador. O SDK valida isso localmente, antes de gastar uma chamada:
+
+```ruby
+boleto = AbacatePay.transparents.create(charge, method: 'BOLETO')
+boleto.bar_code   # linha digitável
+boleto.url        # PDF para impressão
+boleto.br_code    # PIX alternativo da mesma cobrança
+```
+
+## Paginação
+
+Listas retornam no máximo 100 itens. Para percorrer tudo sem lidar com cursor:
+
+```ruby
+AbacatePay.customers.auto_paging_each { |customer| puts customer.name }
+```
+
+## Resiliência
+
+O SDK já traz retry com backoff exponencial e jitter em 429 e 5xx. Escritas nunca são repetidas, porque refazer uma criação de cobrança após timeout poderia cobrar o cliente duas vezes.
+
+```ruby
+AbacatePay.configure do |config|
+  config.api_token   = ENV['ABACATEPAY_API_KEY']
+  config.timeout     = 30  # segundos
+  config.max_retries = 2   # 0 desliga
+  config.logger      = Rails.logger  # opcional, o token é redigido
+end
+```
 
 ## Próximos passos
 

--- a/pages/store/get.mdx
+++ b/pages/store/get.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Obter detalhes da loja'
-openapi: "GET /store/get"
+openapi: "GET /stores/get"
 ---
 
 <Card  horizontal>


### PR DESCRIPTION
Duas divergências entre a documentação e a API, mais a atualização da página de Ruby. Tudo confirmado contra o sandbox com uma chave real.

## 1. `GET /store/get` responde 400

O endpoint é servido no **plural**. Mesma chave, mesmo momento:

```
GET /v2/store/get    ->  HTTP 400
GET /v2/stores/get   ->  HTTP 200
```

`pages/store/get.mdx` declarava `openapi: "GET /store/get"`, então quem seguia a referência recebia erro. Isso já custou um bug no SDK de Ruby, que copiou o caminho documentado.

## 2. O objeto `pagination` não é enviado

A seção de paginação em `pages/reference/introduction.mdx` descreve:

```json
"pagination": { "hasMore": true, "next": "cust_abc123", "before": "cust_xyz789" }
```

A API não envia isso. Verificado em três endpoints, todos com `limit=1` em coleções maiores que 1:

```
customers/list?limit=1  ->  ["data", "error", "success"]
products/list?limit=1   ->  ["data", "error", "success"]
checkouts/list?limit=1  ->  ["data", "error", "success"]
```

Troquei a promessa por um `<Warning>` com o envelope real, orientando usar o `id` do último item como cursor. Deixei a tabela de `limit`/`after`/`before` intacta, já que esses parâmetros funcionam.

Se o `pagination` estiver planejado e ainda não implementado, o caminho inverso também serve: manter a doc e implementar na API. O que não dá é os dois discordarem, porque hoje um SDK que confie na doc quebra.

## 3. Página de Ruby

Atualiza para a 1.2.2, que trouxe recursos que a página não menciona:

- **Boleto**, com vencimento, juros e multa, além do transparente com linha digitável e PIX alternativo
- **Os dois mecanismos de segurança de webhook.** A página só mostrava o HMAC. Como a chave HMAC é pública e global, ela sozinha não prova origem, e o `webhookSecret` da query estava ausente do exemplo
- **Idempotência de webhook**, que a própria documentação de segurança exige
- **Paginação** com `auto_paging_each`
- **Retry com backoff** e as opções de configuração
- Tabela de recursos completa, incluindo `payment_links`, `webhook_endpoints`, `change_plan` e `record_usage`

Incluí também um aviso específico de Rails que custou um bug no app de exemplo: ler `request.query_parameters` em vez de `params` antes de validar, porque tocar em `params` parseia o corpo e um corpo malformado estoura antes do handler rodar, vazando a página de erro do framework num endpoint público.

## Verificação

Todos os exemplos Ruby da página foram executados contra o sandbox antes do commit:

```
OK  boleto com juros e multa                     -> bill_GGS1hMrWng3MFSk4jxLBt4uP
OK  boleto transparente: bar_code, url, br_code  -> bar_code=00191878900000 url=true br_code=true
OK  auto_paging_each                             -> 3 clientes
OK  verify_secret! + construct_event             -> checkout.completed
```