### PR TITLE
fix(openapi): mark id required on /customers/get and /coupons/get

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -205,7 +205,7 @@ paths:
         - name: id
           in: query
           description: Identificador único público do cliente
-          required: false
+          required: true
           schema:
             type: string
             example: cust_aebxkhDZNaMmJeKsy0AHS0FQ
@@ -445,7 +445,7 @@ paths:
         - name: id
           in: query
           description: Identificador único do cupom
-          required: false
+          required: true
           schema:
             type: string
             example: MY_COUPON


### PR DESCRIPTION
## Summary
- Both `GET /customers/get` and `GET /coupons/get` document `id` as their only query parameter, but mark it `required: false` — with no alternative filter documented, there's no way to call either endpoint meaningfully without it.
- Found while building a standing OpenAPI-conformance test suite against this spec in internal services.

## Test plan
- [x] Diff is exactly the 2 `required: false` → `required: true` lines, no other changes
- [x] Verified against the current spec: every other single-parameter `/get` endpoint (`/checkouts/get`, `/payment-links/get`, `/payouts/get`, `/webhooks/get`) already marks its sole parameter required — this brings the two stragglers in line